### PR TITLE
Add in-memory SwiftUI MVVM sample app

### DIFF
--- a/AnonClipsApp.swift
+++ b/AnonClipsApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct AnonClipsApp: App {
+    @StateObject private var appModel = AppModel()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environmentObject(appModel)
+        }
+    }
+}

--- a/AppModel.swift
+++ b/AppModel.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+@MainActor
+final class AppModel: ObservableObject {
+    let videoService: VideoServicing
+    let commentService: CommentServicing
+
+    @Published var totalViews: Int = 0  // Privat total-views för skaparen
+
+    init(videoService: VideoServicing = InMemoryVideoService.shared,
+         commentService: CommentServicing = InMemoryCommentService.shared) {
+        self.videoService = videoService
+        self.commentService = commentService
+    }
+}

--- a/Models/Comment.swift
+++ b/Models/Comment.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct Comment: Identifiable, Hashable {
+    let id: UUID
+    let videoID: UUID
+    var text: String
+    var createdAt: Date
+
+    init(id: UUID = UUID(),
+         videoID: UUID,
+         text: String,
+         createdAt: Date = .now) {
+        self.id = id
+        self.videoID = videoID
+        self.text = text
+        self.createdAt = createdAt
+    }
+}

--- a/Models/Video.swift
+++ b/Models/Video.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+struct Video: Identifiable, Hashable {
+    let id: UUID
+    var title: String
+    var caption: String
+    var duration: TimeInterval
+    var createdAt: Date
+    var viewCount: Int
+
+    init(id: UUID = UUID(),
+         title: String,
+         caption: String,
+         duration: TimeInterval,
+         createdAt: Date = .now,
+         viewCount: Int = 0) {
+        self.id = id
+        self.title = title
+        self.caption = caption
+        self.duration = duration
+        self.createdAt = createdAt
+        self.viewCount = viewCount
+    }
+}

--- a/Services/CommentService.swift
+++ b/Services/CommentService.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+protocol CommentServicing {
+    func fetchComments(for videoID: UUID) -> [Comment]
+    func addComment(_ text: String, to videoID: UUID) -> Comment
+}
+
+@MainActor
+final class InMemoryCommentService: CommentServicing {
+    static let shared = InMemoryCommentService()
+
+    private var store: [UUID: [Comment]] = [:]
+
+    private init() {}
+
+    func fetchComments(for videoID: UUID) -> [Comment] {
+        store[videoID, default: []].sorted { $0.createdAt < $1.createdAt }
+    }
+
+    func addComment(_ text: String, to videoID: UUID) -> Comment {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let comment = Comment(videoID: videoID, text: trimmed)
+        store[videoID, default: []].append(comment)
+        return comment
+    }
+}

--- a/Services/VideoService.swift
+++ b/Services/VideoService.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+protocol VideoServicing {
+    func fetchFeed() -> [Video]
+    func incrementViews(for id: UUID)
+}
+
+@MainActor
+final class InMemoryVideoService: VideoServicing {
+    static let shared = InMemoryVideoService()
+
+    private var videos: [Video]
+
+    private init() {
+        self.videos = [
+            Video(title: "Sommarkväll", caption: "Havet i Nacka", duration: 23),
+            Video(title: "Streetball", caption: "Snabb cross", duration: 17),
+            Video(title: "Latte art", caption: "Så gör du ett hjärta", duration: 28)
+        ]
+    }
+
+    func fetchFeed() -> [Video] {
+        videos
+    }
+
+    func incrementViews(for id: UUID) {
+        if let idx = videos.firstIndex(where: { $0.id == id }) {
+            videos[idx].viewCount += 1
+        }
+    }
+}

--- a/ViewModels/CommentsViewModel.swift
+++ b/ViewModels/CommentsViewModel.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+@MainActor
+final class CommentsViewModel: ObservableObject {
+    @Published private(set) var comments: [Comment] = []
+    @Published var newCommentText: String = ""
+
+    private let videoID: UUID
+    private let commentService: CommentServicing
+
+    init(videoID: UUID, commentService: CommentServicing) {
+        self.videoID = videoID
+        self.commentService = commentService
+        load()
+    }
+
+    func load() {
+        comments = commentService.fetchComments(for: videoID)
+    }
+
+    func send() {
+        let text = newCommentText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return }
+        _ = commentService.addComment(text, to: videoID)
+        newCommentText = ""
+        load()
+    }
+}

--- a/ViewModels/FeedViewModel.swift
+++ b/ViewModels/FeedViewModel.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+@MainActor
+final class FeedViewModel: ObservableObject {
+    @Published private(set) var videos: [Video] = []
+    private let videoService: VideoServicing
+
+    init(videoService: VideoServicing) {
+        self.videoService = videoService
+        load()
+    }
+
+    func load() {
+        videos = videoService.fetchFeed()
+    }
+
+    func recordView(of video: Video, appModel: AppModel) {
+        videoService.incrementViews(for: video.id)
+        appModel.totalViews += 1
+        load()
+    }
+}

--- a/Views/Comments/CommentsView.swift
+++ b/Views/Comments/CommentsView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct CommentsView: View {
+    let video: Video
+    @StateObject private var vm: CommentsViewModel
+
+    init(video: Video) {
+        self.video = video
+        _vm = StateObject(
+            wrappedValue: CommentsViewModel(
+                videoID: video.id,
+                commentService: InMemoryCommentService.shared
+            )
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            List {
+                Section("Kommentarer (anonyma)") {
+                    ForEach(vm.comments) { comment in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(comment.text)
+                            Text(comment.createdAt.formatted(date: .abbreviated, time: .shortened))
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.vertical, 2)
+                    }
+                }
+            }
+            .listStyle(.insetGrouped)
+
+            Divider()
+
+            HStack {
+                TextField("Skriv en kommentar…", text: $vm.newCommentText)
+                    .textFieldStyle(.roundedBorder)
+                Button {
+                    vm.send()
+                } label: {
+                    Image(systemName: "paperplane.fill")
+                }
+                .disabled(vm.newCommentText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+            .padding(12)
+            .background(.thinMaterial)
+        }
+        .navigationTitle("Kommentarer")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/Views/Feed/FeedView.swift
+++ b/Views/Feed/FeedView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct FeedView: View {
+    @EnvironmentObject private var appModel: AppModel
+    @StateObject private var vm: FeedViewModel
+
+    init() {
+        _vm = StateObject(wrappedValue: FeedViewModel(videoService: InMemoryVideoService.shared))
+    }
+
+    var body: some View {
+        List(vm.videos) { video in
+            NavigationLink(value: video) {
+                VideoCardView(video: video)
+            }
+            .listRowInsets(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
+        }
+        .listStyle(.plain)
+        .navigationDestination(for: Video.self) { video in
+            VideoDetailView(video: video)
+                .onAppear {
+                    vm.recordView(of: video, appModel: appModel)
+                }
+        }
+        .refreshable { vm.load() }
+    }
+}

--- a/Views/Feed/VideoCardView.swift
+++ b/Views/Feed/VideoCardView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct VideoCardView: View {
+    let video: Video
+
+    var body: some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 8)
+                .frame(width: 72, height: 96)
+                .overlay(Image(systemName: "play.fill").opacity(0.6))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(video.title).font(.headline)
+                Text(video.caption)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+
+                HStack(spacing: 12) {
+                    Label("\(Int(video.duration))s", systemImage: "clock")
+                    Label("\(video.viewCount)", systemImage: "eye")
+                }
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+    }
+}

--- a/Views/Feed/VideoDetailView.swift
+++ b/Views/Feed/VideoDetailView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+struct VideoDetailView: View {
+    let video: Video
+    @EnvironmentObject private var appModel: AppModel
+
+    var body: some View {
+        ScrollView {
+            RoundedRectangle(cornerRadius: 16)
+                .aspectRatio(9/16, contentMode: .fit)
+                .overlay(
+                    Image(systemName: "video.fill")
+                        .font(.system(size: 48))
+                        .opacity(0.6)
+                )
+                .padding()
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(video.title).font(.title2).bold()
+                Text(video.caption).foregroundStyle(.secondary)
+
+                HStack {
+                    Label("\(Int(video.duration))s", systemImage: "clock")
+                    Label("\(video.viewCount) visningar", systemImage: "eye")
+                }
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+                NavigationLink {
+                    CommentsView(video: video)
+                } label: {
+                    Label("Visa kommentarer", systemImage: "text.bubble")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.top, 12)
+            }
+            .padding(.horizontal)
+        }
+        .navigationTitle("Video")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/Views/RootView.swift
+++ b/Views/RootView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct RootView: View {
+    @EnvironmentObject private var appModel: AppModel
+
+    var body: some View {
+        TabView {
+            NavigationStack {
+                FeedView()
+                    .navigationTitle("AnonClips")
+                    .toolbar {
+                        ToolbarItem(placement: .principal) {
+                            VStack(spacing: 2) {
+                                Text("AnonClips").font(.headline)
+                                Text("Mina visningar: \(appModel.totalViews)")
+                                    .font(.caption2).foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+            }
+            .tabItem { Label("Feed", systemImage: "play.rectangle.fill") }
+
+            NavigationStack {
+                Text("Lägg upp – placeholder")
+                    .padding()
+                    .navigationTitle("Lägg upp")
+            }
+            .tabItem { Label("Lägg upp", systemImage: "plus.square.on.square") }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Scaffold SwiftUI AnonClips app with MVVM architecture
- Implement in-memory video and comment services, models, and view models
- Build feed and comments UI components with state management

## Testing
- `swiftc --version`
- `swiftc AnonClipsApp.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68a07b8b33fc8320abfc91f01b9860bf