### PR TITLE
feat: make feed tiktok style

### DIFF
--- a/AppModel.swift
+++ b/AppModel.swift
@@ -1,4 +1,4 @@
-import Foundation
+import SwiftUI
 
 @MainActor
 final class AppModel: ObservableObject {

--- a/ViewModels/CommentsViewModel.swift
+++ b/ViewModels/CommentsViewModel.swift
@@ -1,4 +1,4 @@
-import Foundation
+import SwiftUI
 
 @MainActor
 final class CommentsViewModel: ObservableObject {

--- a/ViewModels/FeedViewModel.swift
+++ b/ViewModels/FeedViewModel.swift
@@ -1,4 +1,4 @@
-import Foundation
+import SwiftUI
 
 @MainActor
 final class FeedViewModel: ObservableObject {

--- a/Views/Feed/FeedView.swift
+++ b/Views/Feed/FeedView.swift
@@ -21,7 +21,7 @@ struct FeedView: View {
                 }
             }
             .tabViewStyle(.page(indexDisplayMode: .never))
-            .frame(width: proxy.size.height, height: proxy.size.width)
+            .frame(width: proxy.size.width, height: proxy.size.height)
             .rotationEffect(.degrees(90), anchor: .topLeading)
             .offset(x: proxy.size.width)
             .ignoresSafeArea()

--- a/Views/Feed/FeedView.swift
+++ b/Views/Feed/FeedView.swift
@@ -9,19 +9,23 @@ struct FeedView: View {
     }
 
     var body: some View {
-        List(vm.videos) { video in
-            NavigationLink(value: video) {
-                VideoCardView(video: video)
-            }
-            .listRowInsets(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
-        }
-        .listStyle(.plain)
-        .navigationDestination(for: Video.self) { video in
-            VideoDetailView(video: video)
-                .onAppear {
-                    vm.recordView(of: video, appModel: appModel)
+        GeometryReader { proxy in
+            TabView {
+                ForEach(vm.videos) { video in
+                    VideoDetailView(video: video)
+                        .frame(width: proxy.size.width, height: proxy.size.height)
+                        .rotationEffect(.degrees(-90))
+                        .onAppear {
+                            vm.recordView(of: video, appModel: appModel)
+                        }
                 }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .frame(width: proxy.size.height, height: proxy.size.width)
+            .rotationEffect(.degrees(90), anchor: .topLeading)
+            .offset(x: proxy.size.width)
+            .ignoresSafeArea()
         }
-        .refreshable { vm.load() }
+        .onAppear { vm.load() }
     }
 }

--- a/Views/Feed/VideoDetailView.swift
+++ b/Views/Feed/VideoDetailView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct VideoDetailView: View {
     let video: Video
-    @EnvironmentObject private var appModel: AppModel
 
     var body: some View {
         ZStack(alignment: .bottomLeading) {

--- a/Views/Feed/VideoDetailView.swift
+++ b/Views/Feed/VideoDetailView.swift
@@ -5,39 +5,49 @@ struct VideoDetailView: View {
     @EnvironmentObject private var appModel: AppModel
 
     var body: some View {
-        ScrollView {
-            RoundedRectangle(cornerRadius: 16)
-                .aspectRatio(9/16, contentMode: .fit)
+        ZStack(alignment: .bottomLeading) {
+            RoundedRectangle(cornerRadius: 0)
+                .fill(Color.black)
                 .overlay(
                     Image(systemName: "video.fill")
-                        .font(.system(size: 48))
-                        .opacity(0.6)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 80, height: 80)
+                        .foregroundStyle(.white.opacity(0.6))
                 )
-                .padding()
+                .ignoresSafeArea()
 
             VStack(alignment: .leading, spacing: 8) {
-                Text(video.title).font(.title2).bold()
-                Text(video.caption).foregroundStyle(.secondary)
+                Text(video.title)
+                    .font(.title3).bold()
+                Text(video.caption)
+                    .font(.subheadline)
 
-                HStack {
+                HStack(spacing: 12) {
                     Label("\(Int(video.duration))s", systemImage: "clock")
                     Label("\(video.viewCount) visningar", systemImage: "eye")
                 }
-                .font(.footnote)
-                .foregroundStyle(.secondary)
+                .font(.caption)
 
                 NavigationLink {
                     CommentsView(video: video)
                 } label: {
                     Label("Visa kommentarer", systemImage: "text.bubble")
-                        .frame(maxWidth: .infinity)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(.white.opacity(0.9))
+                        .clipShape(Capsule())
                 }
-                .buttonStyle(.borderedProminent)
-                .padding(.top, 12)
+                .buttonStyle(.plain)
+                .padding(.top, 4)
             }
-            .padding(.horizontal)
+            .padding()
+            .foregroundColor(.white)
+            .background(
+                LinearGradient(colors: [Color.black.opacity(0.8), .clear],
+                               startPoint: .bottom, endPoint: .top)
+                    .ignoresSafeArea(edges: .bottom)
+            )
         }
-        .navigationTitle("Video")
-        .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/Views/RootView.swift
+++ b/Views/RootView.swift
@@ -7,8 +7,9 @@ struct RootView: View {
         TabView {
             NavigationStack {
                 FeedView()
-                    .toolbar(.hidden, for: .navigationBar)
             }
+            .navigationBarHidden(true)
+            .ignoresSafeArea()
             .tabItem { Label("Feed", systemImage: "play.rectangle.fill") }
 
             NavigationStack {

--- a/Views/RootView.swift
+++ b/Views/RootView.swift
@@ -7,16 +7,7 @@ struct RootView: View {
         TabView {
             NavigationStack {
                 FeedView()
-                    .navigationTitle("AnonClips")
-                    .toolbar {
-                        ToolbarItem(placement: .principal) {
-                            VStack(spacing: 2) {
-                                Text("AnonClips").font(.headline)
-                                Text("Mina visningar: \(appModel.totalViews)")
-                                    .font(.caption2).foregroundStyle(.secondary)
-                            }
-                        }
-                    }
+                    .toolbar(.hidden, for: .navigationBar)
             }
             .tabItem { Label("Feed", systemImage: "play.rectangle.fill") }
 


### PR DESCRIPTION
## Summary
- revamp feed into full-screen swipeable player
- overlay video details with comment link like TikTok
- remove navigation chrome for immersive start page
- anchor rotated TabView to top-left and offset to fill screen in simulator

## Testing
- `swiftc AnonClipsApp.swift AppModel.swift Models/*.swift Services/*.swift ViewModels/*.swift Views/**/*.swift -o app` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_68a38cbbfffc83208a4f61b2f641ea84